### PR TITLE
Add SSH client to Docker image

### DIFF
--- a/Dockerfile.core
+++ b/Dockerfile.core
@@ -1,7 +1,10 @@
 FROM python:3.12-slim-bookworm
 
-RUN apt-get update && \
-    apt-get install -y jq && \
-    rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y \ 
+    jq \
+    openssh-client \
+    sshpass
+
+RUN rm -rf /var/lib/apt/lists/*
 
 RUN pip install ansible-core==2.*

--- a/Dockerfile.core
+++ b/Dockerfile.core
@@ -1,10 +1,9 @@
 FROM python:3.12-slim-bookworm
 
-RUN apt-get update && apt-get install -y \ 
+RUN apt-get update && apt-get install -y \
     jq \
     openssh-client \
-    sshpass
-
-RUN rm -rf /var/lib/apt/lists/*
+    sshpass && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN pip install ansible-core==2.*

--- a/Dockerfile.full
+++ b/Dockerfile.full
@@ -1,7 +1,10 @@
 FROM python:3.12-slim-bookworm
 
-RUN apt-get update && \
-    apt-get install -y jq && \
-    rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y \ 
+    jq \
+    openssh-client \
+    sshpass
+
+RUN rm -rf /var/lib/apt/lists/*
 
 RUN pip install ansible==9.*

--- a/Dockerfile.full
+++ b/Dockerfile.full
@@ -1,10 +1,9 @@
 FROM python:3.12-slim-bookworm
 
-RUN apt-get update && apt-get install -y \ 
+RUN apt-get update && apt-get install -y \
     jq \
     openssh-client \
-    sshpass
-
-RUN rm -rf /var/lib/apt/lists/*
+    sshpass && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN pip install ansible==9.*


### PR DESCRIPTION
slim-bookworm base image doesn't have SSH client included, adds it.